### PR TITLE
Fix option name in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ import VitePluginBuildMetadata from 'vite-plugin-build-metadata';
 
 export default {
   plugins: [
-    VitePluginBuildMetadata({ filename: 'custom-meta.json' }), // or without .json extension
+    VitePluginBuildMetadata({ fileName: 'custom-meta.json' }), // or without .json extension
   ],
 };
 ```


### PR DESCRIPTION
The option passed to the plugin is `fileName` not `filename`.